### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -60,7 +60,7 @@ func (p *filter) GetCompareFunc(name string) CompareFunc {
 	return p.compareFuncs[name]
 }
 
-// SetFilterTimeout set filter function timeout
+// SetCompareTimeout set filter function timeout
 func (p *filter) SetCompareTimeout(timeout time.Duration) error {
 	p.Lock()
 	defer p.Unlock()


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?